### PR TITLE
Fix for tests folder autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*"
     },
     "autoload": {
-        "classmap": ["src/", "tests/"],
+        "classmap": ["src/"],
         "exclude-from-classmap": []
     },
     "require-dev": {


### PR DESCRIPTION
I tried to install the SDK, but got an exception  
```
Could not scan for classes inside "/var/www/vendor/getmyinvoices/accounts-api-php/tests/" which does not appear to be a file nor a folder
```
Composer was trying to autoload classes from `tests` folder that doesn't exist.
This should fix it.